### PR TITLE
feat: add peer-relay options

### DIFF
--- a/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js
+++ b/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js
@@ -24,7 +24,8 @@ const tailscaleSettingsConf = [
 	[form.Flag, 'nosnat', _('Disable SNAT'), _('Disable Source NAT (SNAT) for traffic to advertised routes. Most users should leave this unchecked.'), { rmempty: false }],
 	[form.Flag, 'shields_up', _('Shields Up'), _('When enabled, blocks all inbound connections from the Tailscale network.'), { rmempty: false }],
 	[form.Flag, 'ssh', _('Enable Tailscale SSH'), _('Allow connecting to this device through the SSH function of Tailscale.'), { rmempty: false }],
-	[form.Flag, 'disable_magic_dns', _('Disable MagicDNS'), _('Use system DNS instead of MagicDNS.'), { rmempty: false }]
+	[form.Flag, 'disable_magic_dns', _('Disable MagicDNS'), _('Use system DNS instead of MagicDNS.'), { rmempty: false }],
+	[form.Flag, 'enable_relay', _('Enable Peer Relay'), _('Enable this device as a Peer Relay server. Requires a public IP and an UDP port open on the router.'), { rmempty: false }]
 ];
 
 const accountConf = [];	// dynamic created in render function
@@ -375,6 +376,14 @@ return view.extend({
 
 		defTabOpts(s, 'general', tailscaleSettingsConf, { optional: false });
 
+		const relayPort = s.taboption('general', form.Value, 'relay_server_port', _('Peer Relay Port'),
+			_('UDP port for the Peer Relay service. Open this port on your router firewall/NAT.')
+		);
+		relayPort.datatype = 'port';
+		relayPort.placeholder = '40000';
+		relayPort.rmempty = false;
+		relayPort.depends('enable_relay', '1');
+
 		const en = s.taboption('general', form.ListValue, 'exit_node', _('Exit Node'), _('Select an exit node from the list. If enabled, Allow LAN Access is enabled implicitly.'));
 		en.value('', _('None'));
 		if (status.peers) {
@@ -567,6 +576,7 @@ return view.extend({
 			if(!data.exit_node) data.exit_node = '';
 			if(!data.custom_login_url) data.custom_login_url = '';
 			if(!data.custom_login_AuthKey) data.custom_login_AuthKey = '';
+			if(!data.relay_server_port) data.relay_server_port = '';
 
 			ui.showModal(_('Applying changes...'), E('em', {}, _('Please wait.')));
 

--- a/luci-app-tailscale-community/po/templates/community.pot
+++ b/luci-app-tailscale-community/po/templates/community.pot
@@ -1,21 +1,21 @@
 msgid ""
 msgstr "Content-Type: text/plain; charset=UTF-8"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:34
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:35
 msgid "(Experimental) Reduce Memory Usage"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:434
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:443
 msgid "1. Select \"Accept Routes\" (to access remote devices)."
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:435
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:444
 msgid ""
 "2. In \"Advertise Routes\", select your local subnet (to allow remote "
 "devices to access this LAN)."
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:436
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:445
 msgid "3. Click \"Auto Configure Firewall\" (to allow traffic forwarding)."
 msgstr ""
 
@@ -23,7 +23,7 @@ msgstr ""
 msgid "Accept Routes"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:443
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:452
 msgid "Account Settings"
 msgstr ""
 
@@ -31,11 +31,11 @@ msgstr ""
 msgid "Advertise Exit Node"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:402
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:411
 msgid "Advertise Routes"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:402
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:411
 msgid ""
 "Advertise subnet routes behind this device. Select from the detected subnets "
 "below or enter custom routes (comma-separated)."
@@ -57,55 +57,55 @@ msgstr ""
 msgid "Allow user access to tailscale"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:571
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:581
 msgid "Applying changes..."
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:517
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:526
 msgid "Are you sure you want to log out?"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:410
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:419
 msgid "Auto Configure Firewall"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:524
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:533
 msgid "Cancel"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:468
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:477
 msgid "Click to Log out account on this device."
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:447
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:456
 msgid "Click to get a login URL for this device."
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:166
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:243
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:365
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:167
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:244
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:366
 msgid "Collecting data ..."
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:543
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:552
 msgid "Confirm Logout"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:264
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:265
 msgid "Connection Info"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:480
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:489
 msgid ""
 "Could not open a new tab. Please check if your browser or an extension "
 "blocked the pop-up."
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:452
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:461
 msgid "Custom Login Server"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:460
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:469
 msgid "Custom Login Server Auth Key"
 msgstr ""
 
@@ -113,7 +113,7 @@ msgstr ""
 msgid "Declare this device as an Exit Node."
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:546
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:555
 msgid "Devices List"
 msgstr ""
 
@@ -131,12 +131,16 @@ msgid ""
 "should leave this unchecked."
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:226
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:227
 msgid "Disabled"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:469
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:478
 msgid "Disconnect from Tailscale and expire current node key."
+msgstr ""
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:28
+msgid "Enable Peer Relay"
 msgstr ""
 
 #: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:26
@@ -147,48 +151,54 @@ msgstr ""
 msgid "Enable Web Interface"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:226
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:28
+msgid ""
+"Enable this device as a Peer Relay server. Requires a public IP and an UDP "
+"port open on the router."
+msgstr ""
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:227
 msgid "Enabled"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:34
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:35
 msgid ""
 "Enabling this option can reduce memory usage, but it may sacrifice some "
 "performance (set GOGC=10)."
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:505
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:514
 msgid "Error"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:586
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:596
 msgid "Error applying settings: %s"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:147
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:148
 msgid "Error caching DERP region map: %s"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:150
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:151
 msgid "Error fetching DERP region map: %s"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:120
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:121
 msgid "Error reading cached DERP region map: %s"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:582
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:592
 msgid "Error saving settings: %s"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:411
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:420
 msgid ""
 "Essential configuration for Subnet Routing (Site-to-Site) and Exit Node "
 "features."
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:286
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:378
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:287
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:387
 msgid "Exit Node"
 msgstr ""
 
@@ -197,23 +207,23 @@ msgid ""
 "Expose a web interface on port 5252 for managing this node over Tailscale."
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:422
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:431
 msgid "Failed to configure firewall: %s"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:506
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:515
 msgid "Failed to get login URL. You may close this tab."
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:511
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:520
 msgid "Failed to get login URL: %s"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:507
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:516
 msgid "Failed to get login URL: Invalid response from server."
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:592
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:602
 msgid "Failed to save settings: %s"
 msgstr ""
 
@@ -221,149 +231,153 @@ msgstr ""
 msgid "Firewall Mode"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:419
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:428
 msgid "Firewall configuration applied."
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:374
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:375
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:261
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:262
 msgid "Hostname"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:429
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:438
 msgid "How to enable Site-to-Site?"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:448
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:457
 msgid ""
 "If the timeout is displayed, you can refresh the page and click Login again."
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:462
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:471
 msgid ""
 "If you are using custom login server but not providing an Auth Key, will "
 "redirect to the login page without pre-filling the key."
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:90
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:91
 msgid "Invalid Date"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:412
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:421
 msgid ""
 "It automatically creates the tailscale interface, sets up firewall zones for "
 "LAN <-> Tailscale forwarding,"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:93
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:94
 msgid "Just now"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:205
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:206
 msgid "LOGGED OUT"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:267
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:268
 msgid "Last Seen"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:454
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:463
 msgid "Leave blank for default Tailscale control plane."
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:530
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:539
 msgid "Logging out..."
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:446
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:455
 msgid "Login"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:467
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:540
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:476
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:549
 msgid "Logout"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:537
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:546
 msgid "Logout failed: %s"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:87
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:88
 msgid "N/A"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:216
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:217
 msgid "NOT RUNNING"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:256
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:257
 msgid "No peer devices found."
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:379
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:388
 msgid "None"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:88
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:89
 msgid "Now"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:263
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:264
 msgid "OS"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:286
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:287
 msgid "Offline"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:286
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:287
 msgid "Online"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:453
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:462
 msgid ""
 "Optional: Specify a custom control server URL (e.g., a Headscale instance, "
 "https://example.com)."
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:461
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:470
 msgid ""
 "Optional: Specify an authentication key for the custom control server. Leave "
 "blank if not required."
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:207
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:379
+msgid "Peer Relay Port"
+msgstr ""
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:208
 msgid "Please use the login button in the settings below to authenticate."
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:490
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:496
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:530
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:571
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:499
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:505
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:539
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:581
 msgid "Please wait."
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:224
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:225
 msgid "RUNNING"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:265
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:266
 msgid "RX"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:490
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:496
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:499
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:505
 msgid "Requesting Login URL..."
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:487
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:496
 msgid "Requesting Tailscale login URL... Please wait."
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:378
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:387
 msgid ""
 "Select an exit node from the list. If enabled, Allow LAN Access is enabled "
 "implicitly."
@@ -375,10 +389,10 @@ msgid ""
 "to take effect."
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:195
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:203
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:215
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:224
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:196
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:204
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:216
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:225
 msgid "Service Status"
 msgstr ""
 
@@ -386,87 +400,93 @@ msgstr ""
 msgid "Shields Up"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:260
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:261
 msgid "Status"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:534
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:543
 msgid "Successfully logged out."
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:196
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:197
 msgid "TAILSCALE NOT FOUND"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:226
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:227
 msgid "TUN Mode"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:266
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:267
 msgid "TX"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:229
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:230
 msgid "Tailnet Name"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:339
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:340
 #: applications/luci-app-tailscale-community/root/usr/share/luci/menu.d/luci-app-tailscale-community.json:3
 msgid "Tailscale"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:172
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:173
 msgid "Tailscale Health Check: %s"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:262
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:263
 msgid "Tailscale IP"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:227
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:228
 msgid "Tailscale IPv4"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:228
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:229
 msgid "Tailscale IPv6"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:486
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:495
 msgid "Tailscale Login"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:339
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:340
 msgid ""
 "Tailscale is a mesh VPN solution that makes it easy to connect your devices "
 "securely. This configuration page allows you to manage Tailscale settings on "
 "your OpenWrt device."
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:577
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:587
 msgid "Tailscale settings applied successfully."
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:247
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:248
 msgid "Tailscale status error"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:488
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:497
 msgid "This can take up to 30 seconds."
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:518
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:527
 msgid ""
 "This will disconnect this device from your Tailnet and require you to re-"
 "authenticate."
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:120
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:147
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:150
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:511
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:537
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:582
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:586
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:380
+msgid ""
+"UDP port for the Peer Relay service. Open this port on your router firewall/"
+"NAT."
+msgstr ""
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:121
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:148
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:151
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:520
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:546
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:592
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:596
 msgid "Unknown error"
 msgstr ""
 
@@ -474,7 +494,7 @@ msgstr ""
 msgid "Use system DNS instead of MagicDNS."
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:225
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:226
 msgid "Version"
 msgstr ""
 
@@ -487,17 +507,17 @@ msgstr ""
 msgid "When using the exit node, access to the local LAN is allowed."
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:437
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:446
 msgid ""
 "[Important] Log in to the Tailscale admin console and manually enable "
 "\"Subnet Routes\" for this device."
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:96
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:97
 msgid "ago"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:413
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:422
 msgid ""
 "and enables Masquerading and MSS Clamping (MTU fix) to ensure stable "
 "connections."

--- a/luci-app-tailscale-community/po/zh_Hans/community.po
+++ b/luci-app-tailscale-community/po/zh_Hans/community.po
@@ -1,21 +1,21 @@
 msgid ""
 msgstr "Content-Type: text/plain; charset=UTF-8\n"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:34
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:35
 msgid "(Experimental) Reduce Memory Usage"
 msgstr "(实验性) 减少内存使用"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:434
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:443
 msgid "1. Select \"Accept Routes\" (to access remote devices)."
 msgstr "1. 勾选 接受路由 (接受远程设备访问)。"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:435
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:444
 msgid ""
 "2. In \"Advertise Routes\", select your local subnet (to allow remote "
 "devices to access this LAN)."
 msgstr "2. 在 通告路由 选择本设备的局域网段 (让远程设备能访问你)。"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:436
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:445
 msgid "3. Click \"Auto Configure Firewall\" (to allow traffic forwarding)."
 msgstr "3. 点击 自动配置防火墙 (打通防火墙转发)。"
 
@@ -23,7 +23,7 @@ msgstr "3. 点击 自动配置防火墙 (打通防火墙转发)。"
 msgid "Accept Routes"
 msgstr "接受路由"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:443
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:452
 msgid "Account Settings"
 msgstr "账户设置"
 
@@ -31,11 +31,11 @@ msgstr "账户设置"
 msgid "Advertise Exit Node"
 msgstr "通告出口节点"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:402
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:411
 msgid "Advertise Routes"
 msgstr "通告路由"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:402
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:411
 msgid ""
 "Advertise subnet routes behind this device. Select from the detected subnets "
 "below or enter custom routes (comma-separated)."
@@ -58,55 +58,55 @@ msgstr "允许通过 Tailscale 的 SSH 功能连接到此设备。"
 msgid "Allow user access to tailscale"
 msgstr "允许用户访问 Tailscale"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:571
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:581
 msgid "Applying changes..."
 msgstr "正在应用更改..."
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:517
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:526
 msgid "Are you sure you want to log out?"
 msgstr "您确定要登出吗？"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:410
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:419
 msgid "Auto Configure Firewall"
 msgstr "自动配置防火墙"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:524
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:533
 msgid "Cancel"
 msgstr "取消"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:468
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:477
 msgid "Click to Log out account on this device."
 msgstr "点击以登出此设备上的账户。"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:447
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:456
 msgid "Click to get a login URL for this device."
 msgstr "点击获取此设备的登录 URL。"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:166
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:243
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:365
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:167
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:244
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:366
 msgid "Collecting data ..."
 msgstr "正在收集数据..."
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:543
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:552
 msgid "Confirm Logout"
 msgstr "确认登出"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:264
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:265
 msgid "Connection Info"
 msgstr "连接信息"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:480
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:489
 msgid ""
 "Could not open a new tab. Please check if your browser or an extension "
 "blocked the pop-up."
 msgstr "无法打开新标签页。请检查您的浏览器或扩展程序是否阻止了弹出窗口。"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:452
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:461
 msgid "Custom Login Server"
 msgstr "自定义登录服务器"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:460
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:469
 msgid "Custom Login Server Auth Key"
 msgstr "自定义登录服务器认证密钥"
 
@@ -114,7 +114,7 @@ msgstr "自定义登录服务器认证密钥"
 msgid "Declare this device as an Exit Node."
 msgstr "将此设备声明为出口节点。"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:546
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:555
 msgid "Devices List"
 msgstr "设备列表"
 
@@ -132,13 +132,17 @@ msgid ""
 "should leave this unchecked."
 msgstr "为通告路由的流量禁用源地址转换 (SNAT)。大多数用户应保持此项不勾选。"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:226
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:227
 msgid "Disabled"
 msgstr "已禁用"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:469
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:478
 msgid "Disconnect from Tailscale and expire current node key."
 msgstr "从 Tailscale 断开连接并使当前节点密钥过期。"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:28
+msgid "Enable Peer Relay"
+msgstr "启用对等中继"
 
 #: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:26
 msgid "Enable Tailscale SSH"
@@ -148,48 +152,54 @@ msgstr "启用 Tailscale SSH"
 msgid "Enable Web Interface"
 msgstr "启用 Web 界面"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:226
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:28
+msgid ""
+"Enable this device as a Peer Relay server. Requires a public IP and an UDP "
+"port open on the router."
+msgstr "将此设备做为对等中继服务器。需要公网 IP 并在路由器上开放对应 UDP 端口。"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:227
 msgid "Enabled"
 msgstr "已启用"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:34
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:35
 msgid ""
 "Enabling this option can reduce memory usage, but it may sacrifice some "
 "performance (set GOGC=10)."
 msgstr "启用此选项可以减少内存使用，但可能会牺牲一些性能 (设置 GOGC=10)。"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:505
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:514
 msgid "Error"
 msgstr "错误"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:586
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:596
 msgid "Error applying settings: %s"
 msgstr "应用设置时出错: %s"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:147
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:148
 msgid "Error caching DERP region map: %s"
 msgstr "缓存 DERP 区域地图时出错: %s"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:150
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:151
 msgid "Error fetching DERP region map: %s"
 msgstr "获取 DERP 区域地图时出错: %s"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:120
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:121
 msgid "Error reading cached DERP region map: %s"
 msgstr "读取缓存的 DERP 区域地图时出错: %s"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:582
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:592
 msgid "Error saving settings: %s"
 msgstr "保存设置时出错: %s"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:411
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:420
 msgid ""
 "Essential configuration for Subnet Routing (Site-to-Site) and Exit Node "
 "features."
 msgstr "子网路由和出口节点的基本配置。"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:286
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:378
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:287
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:387
 msgid "Exit Node"
 msgstr "出口节点"
 
@@ -198,23 +208,23 @@ msgid ""
 "Expose a web interface on port 5252 for managing this node over Tailscale."
 msgstr "在端口 5252 上暴露一个 Web 界面，用于通过 Tailscale 管理此节点。"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:422
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:431
 msgid "Failed to configure firewall: %s"
 msgstr "获取防火墙设置失败: %s"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:506
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:515
 msgid "Failed to get login URL. You may close this tab."
 msgstr "获取登录 URL 失败。您可以关闭此标签页。"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:511
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:520
 msgid "Failed to get login URL: %s"
 msgstr "获取登录 URL 失败: %s"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:507
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:516
 msgid "Failed to get login URL: Invalid response from server."
 msgstr "获取登录 URL 失败: 服务器响应无效。"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:592
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:602
 msgid "Failed to save settings: %s"
 msgstr "保存设置失败: %s"
 
@@ -222,28 +232,28 @@ msgstr "保存设置失败: %s"
 msgid "Firewall Mode"
 msgstr "防火墙模式"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:419
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:428
 msgid "Firewall configuration applied."
 msgstr "已应用防火墙配置"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:374
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:375
 msgid "General Settings"
 msgstr "常规设置"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:261
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:262
 msgid "Hostname"
 msgstr "主机名"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:429
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:438
 msgid "How to enable Site-to-Site?"
 msgstr "如何启用端到端访问？"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:448
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:457
 msgid ""
 "If the timeout is displayed, you can refresh the page and click Login again."
 msgstr "如果显示超时，您可以刷新页面并再次点击登录。"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:462
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:471
 msgid ""
 "If you are using custom login server but not providing an Auth Key, will "
 "redirect to the login page without pre-filling the key."
@@ -251,11 +261,11 @@ msgstr ""
 "如果您使用自定义登录服务器但未提供认证密钥，将重定向到登录页面而不会预先填充"
 "密钥。"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:90
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:91
 msgid "Invalid Date"
 msgstr "无效日期"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:412
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:421
 msgid ""
 "It automatically creates the tailscale interface, sets up firewall zones for "
 "LAN <-> Tailscale forwarding,"
@@ -263,72 +273,72 @@ msgstr ""
 "子网路由和出口节点的基本配置。会自动tailscale接口，设置防火墙区域LAN <-> "
 "Tailscale转发"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:93
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:94
 msgid "Just now"
 msgstr "刚才"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:205
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:206
 msgid "LOGGED OUT"
 msgstr "已登出"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:267
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:268
 msgid "Last Seen"
 msgstr "上次在线"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:454
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:463
 msgid "Leave blank for default Tailscale control plane."
 msgstr "留空以使用默认的 Tailscale 控制平面。"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:530
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:539
 msgid "Logging out..."
 msgstr "正在登出..."
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:446
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:455
 msgid "Login"
 msgstr "登录"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:467
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:540
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:476
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:549
 msgid "Logout"
 msgstr "登出"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:537
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:546
 msgid "Logout failed: %s"
 msgstr "登出失败: %s"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:87
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:88
 msgid "N/A"
 msgstr "N/A"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:216
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:217
 msgid "NOT RUNNING"
 msgstr "未运行"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:256
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:257
 msgid "No peer devices found."
 msgstr "未找到对等设备。"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:379
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:388
 msgid "None"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:88
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:89
 msgid "Now"
 msgstr "现在"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:263
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:264
 msgid "OS"
 msgstr "操作系统"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:286
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:287
 msgid "Offline"
 msgstr "离线"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:286
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:287
 msgid "Online"
 msgstr "在线"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:453
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:462
 msgid ""
 "Optional: Specify a custom control server URL (e.g., a Headscale instance, "
 "https://example.com)."
@@ -336,41 +346,45 @@ msgstr ""
 "可选：指定一个自定义控制服务器 URL (例如，一个 Headscale 实例，https://"
 "example.com)。"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:461
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:470
 msgid ""
 "Optional: Specify an authentication key for the custom control server. Leave "
 "blank if not required."
 msgstr "可选：为自定义控制服务器指定一个认证密钥。如果不需要，请留空。"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:207
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:379
+msgid "Peer Relay Port"
+msgstr "对等中继端口"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:208
 msgid "Please use the login button in the settings below to authenticate."
 msgstr "请使用下方设置中的登录按钮进行认证。"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:490
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:496
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:530
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:571
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:499
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:505
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:539
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:581
 msgid "Please wait."
 msgstr "请稍候。"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:224
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:225
 msgid "RUNNING"
 msgstr "正在运行"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:265
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:266
 msgid "RX"
 msgstr "接收"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:490
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:496
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:499
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:505
 msgid "Requesting Login URL..."
 msgstr "正在请求登录 URL..."
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:487
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:496
 msgid "Requesting Tailscale login URL... Please wait."
 msgstr "正在请求 Tailscale 登录 URL... 请稍候。"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:378
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:387
 msgid ""
 "Select an exit node from the list. If enabled, Allow LAN Access is enabled "
 "implicitly."
@@ -382,10 +396,10 @@ msgid ""
 "to take effect."
 msgstr "选择 Tailscale 使用的防火墙后端。需要重启服务才能生效。"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:195
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:203
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:215
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:224
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:196
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:204
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:216
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:225
 msgid "Service Status"
 msgstr "服务状态"
 
@@ -393,56 +407,56 @@ msgstr "服务状态"
 msgid "Shields Up"
 msgstr "开启防护 (Shields Up)"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:260
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:261
 msgid "Status"
 msgstr "状态"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:534
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:543
 msgid "Successfully logged out."
 msgstr "登出成功。"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:196
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:197
 msgid "TAILSCALE NOT FOUND"
 msgstr "未找到 TAILSCALE"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:226
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:227
 msgid "TUN Mode"
 msgstr "TUN 模式"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:266
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:267
 msgid "TX"
 msgstr "发送"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:229
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:230
 msgid "Tailnet Name"
 msgstr "Tailnet 名称"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:339
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:340
 #: applications/luci-app-tailscale-community/root/usr/share/luci/menu.d/luci-app-tailscale-community.json:3
 msgid "Tailscale"
 msgstr "Tailscale"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:172
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:173
 msgid "Tailscale Health Check: %s"
 msgstr "Tailscale 健康检查: %s"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:262
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:263
 msgid "Tailscale IP"
 msgstr "Tailscale IP"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:227
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:228
 msgid "Tailscale IPv4"
 msgstr "Tailscale IPv4"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:228
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:229
 msgid "Tailscale IPv6"
 msgstr "Tailscale IPv6"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:486
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:495
 msgid "Tailscale Login"
 msgstr "Tailscale 登录"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:339
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:340
 msgid ""
 "Tailscale is a mesh VPN solution that makes it easy to connect your devices "
 "securely. This configuration page allows you to manage Tailscale settings on "
@@ -451,31 +465,37 @@ msgstr ""
 "Tailscale 是一个网状 VPN 解决方案，可以轻松地安全连接您的设备。此配置页面允许"
 "您在 OpenWrt 设备上管理 Tailscale 设置。"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:577
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:587
 msgid "Tailscale settings applied successfully."
 msgstr "Tailscale 设置已成功应用。"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:247
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:248
 msgid "Tailscale status error"
 msgstr "Tailscale 状态异常"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:488
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:497
 msgid "This can take up to 30 seconds."
 msgstr "此过程最多可能需要 30 秒。"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:518
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:527
 msgid ""
 "This will disconnect this device from your Tailnet and require you to re-"
 "authenticate."
 msgstr "这将使此设备从您的 Tailnet 断开连接，并需要您重新进行身份验证。"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:120
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:147
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:150
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:511
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:537
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:582
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:586
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:380
+msgid ""
+"UDP port for the Peer Relay service. Open this port on your router firewall/"
+"NAT."
+msgstr "对等中继服务的 UDP 端口。请在您的路由器防火墙上打开此端口。"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:121
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:148
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:151
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:520
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:546
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:592
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:596
 msgid "Unknown error"
 msgstr "未知错误"
 
@@ -483,7 +503,7 @@ msgstr "未知错误"
 msgid "Use system DNS instead of MagicDNS."
 msgstr "使用系统 DNS 而不是 MagicDNS。"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:225
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:226
 msgid "Version"
 msgstr "版本"
 
@@ -496,17 +516,17 @@ msgstr "启用后，将阻止来自 Tailscale 网络的所有入站连接。"
 msgid "When using the exit node, access to the local LAN is allowed."
 msgstr "使用出口节点时，允许访问本地局域网。"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:437
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:446
 msgid ""
 "[Important] Log in to the Tailscale admin console and manually enable "
 "\"Subnet Routes\" for this device."
 msgstr "【重要】 登录 Tailscale 控制台，在设备设置中手动授权子网路由。"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:96
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:97
 msgid "ago"
 msgstr "前"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:413
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:422
 msgid ""
 "and enables Masquerading and MSS Clamping (MTU fix) to ensure stable "
 "connections."


### PR DESCRIPTION
https://tailscale.com/blog/peer-relays-ga
可能需要 tailscale 1.86+ 才支持
openwrt-23.05 / openwrt-24.10 需要升级 tailscale 才可开启
<img width="1301" height="331" alt="image" src="https://github.com/user-attachments/assets/d8b5b490-8c3a-42c6-ac96-139d1287f7c7" />
