### PR TITLE
重构DNS设置，移除disable_magic_dns选项并引入dns_mode选项以支持多种DNS模式

### DIFF
--- a/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js
+++ b/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js
@@ -24,7 +24,7 @@ const tailscaleSettingsConf = [
 	[form.Flag, 'nosnat', _('Disable SNAT'), _('Disable Source NAT (SNAT) for traffic to advertised routes. Most users should leave this unchecked.'), { rmempty: false }],
 	[form.Flag, 'shields_up', _('Shields Up'), _('When enabled, blocks all inbound connections from the Tailscale network.'), { rmempty: false }],
 	[form.Flag, 'ssh', _('Enable Tailscale SSH'), _('Allow connecting to this device through the SSH function of Tailscale.'), { rmempty: false }],
-	[form.Flag, 'disable_magic_dns', _('Disable MagicDNS'), _('Use system DNS instead of MagicDNS.'), { rmempty: false }],
+	[form.ListValue, 'dns_mode', _('DNS Mode'), _('Controls how Tailscale DNS is handled. Disabled: system DNS only. MagicDNS: Tailscale overrides resolv.conf. OpenWrt Forward: MagicDNS via dnsmasq forwarding.'), { values: [['disabled', _('Disabled')], ['magicdns', 'MagicDNS'], ['openwrt_forward', _('OpenWrt Forward')]], rmempty: false }],
 	[form.Flag, 'enable_relay', _('Enable Peer Relay'), _('Enable this device as a Peer Relay server. Requires a public IP and an UDP port open on the router.'), { rmempty: false }]
 ];
 
@@ -322,10 +322,18 @@ return view.extend({
 					uci.set('tailscale', 'settings', 'shields_up', ((settings_from_rpc.shields_up || false) ? '1' : '0'));
 					uci.set('tailscale', 'settings', 'runwebclient', ((settings_from_rpc.runwebclient || false) ? '1' : '0'));
 					uci.set('tailscale', 'settings', 'nosnat', ((settings_from_rpc.nosnat || false) ? '1' : '0'));
-					uci.set('tailscale', 'settings', 'disable_magic_dns', ((settings_from_rpc.disable_magic_dns || false) ? '1' : '0'));
+					uci.set('tailscale', 'settings', 'dns_mode', 'disabled');
 
 					uci.set('tailscale', 'settings', 'daemon_reduce_memory', '0');
 					uci.set('tailscale', 'settings', 'daemon_mtu', '');
+					return uci.save();
+				}
+			}).then(function() {
+				// Migrate from old disable_magic_dns to dns_mode if needed
+				if (uci.get('tailscale', 'settings', 'dns_mode') === null) {
+					var oldMagicDns = uci.get('tailscale', 'settings', 'disable_magic_dns');
+					uci.set('tailscale', 'settings', 'dns_mode', oldMagicDns === '1' ? 'disabled' : 'magicdns');
+					uci.unset('tailscale', 'settings', 'disable_magic_dns');
 					return uci.save();
 				}
 			}).then(function() {

--- a/luci-app-tailscale-community/po/es/community.po
+++ b/luci-app-tailscale-community/po/es/community.po
@@ -123,10 +123,6 @@ msgstr ""
 msgid "Devices List"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:27
-msgid "Disable MagicDNS"
-msgstr ""
-
 #: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:24
 msgid "Disable SNAT"
 msgstr ""
@@ -136,6 +132,18 @@ msgid ""
 "Disable Source NAT (SNAT) for traffic to advertised routes. Most users "
 "should leave this unchecked."
 msgstr ""
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:27
+msgid "DNS Mode"
+msgstr "Modo DNS"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:27
+msgid "Controls how Tailscale DNS is handled. Disabled: system DNS only. MagicDNS: Tailscale overrides resolv.conf. OpenWrt Forward: MagicDNS via dnsmasq forwarding."
+msgstr ""
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:27
+msgid "OpenWrt Forward"
+msgstr "Reenvío OpenWrt"
 
 #: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:227
 msgid "Disabled"
@@ -485,10 +493,6 @@ msgstr ""
 #: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:521
 #: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:547
 msgid "Unknown error"
-msgstr ""
-
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:27
-msgid "Use system DNS instead of MagicDNS."
 msgstr ""
 
 #: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:226

--- a/luci-app-tailscale-community/po/templates/community.pot
+++ b/luci-app-tailscale-community/po/templates/community.pot
@@ -113,9 +113,6 @@ msgstr ""
 msgid "Devices List"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:27
-msgid "Disable MagicDNS"
-msgstr ""
 
 #: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:24
 msgid "Disable SNAT"
@@ -125,6 +122,18 @@ msgstr ""
 msgid ""
 "Disable Source NAT (SNAT) for traffic to advertised routes. Most users "
 "should leave this unchecked."
+msgstr ""
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:27
+msgid "DNS Mode"
+msgstr ""
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:27
+msgid "Controls how Tailscale DNS is handled. Disabled: system DNS only. MagicDNS: Tailscale overrides resolv.conf. OpenWrt Forward: MagicDNS via dnsmasq forwarding."
+msgstr ""
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:27
+msgid "OpenWrt Forward"
 msgstr ""
 
 #: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:227
@@ -477,9 +486,6 @@ msgstr ""
 msgid "Unknown error"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:27
-msgid "Use system DNS instead of MagicDNS."
-msgstr ""
 
 #: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:226
 msgid "Version"

--- a/luci-app-tailscale-community/po/zh_Hans/community.po
+++ b/luci-app-tailscale-community/po/zh_Hans/community.po
@@ -114,10 +114,6 @@ msgstr "将此设备声明为出口节点。"
 msgid "Devices List"
 msgstr "设备列表"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:27
-msgid "Disable MagicDNS"
-msgstr "禁用 MagicDNS"
-
 #: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:24
 msgid "Disable SNAT"
 msgstr "禁用 SNAT"
@@ -127,6 +123,18 @@ msgid ""
 "Disable Source NAT (SNAT) for traffic to advertised routes. Most users "
 "should leave this unchecked."
 msgstr "为通告路由的流量禁用源地址转换 (SNAT)。大多数用户应保持此项不勾选。"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:27
+msgid "DNS Mode"
+msgstr "DNS 模式"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:27
+msgid "Controls how Tailscale DNS is handled. Disabled: system DNS only. MagicDNS: Tailscale overrides resolv.conf. OpenWrt Forward: MagicDNS via dnsmasq forwarding."
+msgstr ""
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:27
+msgid "OpenWrt Forward"
+msgstr "OpenWrt 转发"
 
 #: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:227
 msgid "Disabled"
@@ -483,10 +491,6 @@ msgstr "DERP的UDP端口号。需要在防火墙/NAT规则中开放该端口。"
 #: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:547
 msgid "Unknown error"
 msgstr "未知错误"
-
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:27
-msgid "Use system DNS instead of MagicDNS."
-msgstr "使用系统 DNS 而不是 MagicDNS。"
 
 #: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:226
 msgid "Version"

--- a/luci-app-tailscale-community/po/zh_Hant/community.po
+++ b/luci-app-tailscale-community/po/zh_Hant/community.po
@@ -114,10 +114,6 @@ msgstr "將此裝置宣告為出口節點。"
 msgid "Devices List"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:27
-msgid "Disable MagicDNS"
-msgstr "停用 MagicDNS"
-
 #: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:24
 msgid "Disable SNAT"
 msgstr "停用 SNAT"
@@ -127,6 +123,18 @@ msgid ""
 "Disable Source NAT (SNAT) for traffic to advertised routes. Most users "
 "should leave this unchecked."
 msgstr "為通告路由的流量停用源地址轉換 (SNAT)。大多數使用者應保持此項不勾選。"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:27
+msgid "DNS Mode"
+msgstr "DNS 模式"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:27
+msgid "Controls how Tailscale DNS is handled. Disabled: system DNS only. MagicDNS: Tailscale overrides resolv.conf. OpenWrt Forward: MagicDNS via dnsmasq forwarding."
+msgstr ""
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:27
+msgid "OpenWrt Forward"
+msgstr "OpenWrt 轉發"
 
 #: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:227
 msgid "Disabled"
@@ -483,10 +491,6 @@ msgstr ""
 #: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:547
 msgid "Unknown error"
 msgstr "未知錯誤"
-
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:27
-msgid "Use system DNS instead of MagicDNS."
-msgstr "使用系統 DNS 而不是 MagicDNS。"
 
 #: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:226
 msgid "Version"

--- a/luci-app-tailscale-community/root/etc/init.d/tailscale-settings
+++ b/luci-app-tailscale-community/root/etc/init.d/tailscale-settings
@@ -31,17 +31,9 @@ setup_tailscale_dns_forward() {
 	local found=0
 
 	# Check if entry already exists in dnsmasq
-	local idx=0
-	while true; do
-		local val
-		val=$(uci -q get dhcp.@dnsmasq[0].server."${idx}" 2>/dev/null)
-		[ -z "$val" ] && break
-		if [ "$val" = "$entry" ]; then
-			found=1
-			break
-		fi
-		idx=$((idx + 1))
-	done
+	if uci -q show dhcp.@dnsmasq[0].server 2>/dev/null | grep -Fqx "dhcp.@dnsmasq[0].server='$entry'"; then
+		found=1
+	fi
 
 	if [ "$found" = "0" ]; then
 		uci add_list dhcp.@dnsmasq[0].server="$entry"

--- a/luci-app-tailscale-community/root/etc/init.d/tailscale-settings
+++ b/luci-app-tailscale-community/root/etc/init.d/tailscale-settings
@@ -23,12 +23,7 @@ version_gte() {
 
 # Add/remove DNS forward entry in dnsmasq for MagicDNS via OpenWrt
 setup_tailscale_dns_forward() {
-	local ts_bin
-	if [ -x /usr/sbin/tailscale ]; then
-		ts_bin=/usr/sbin/tailscale
-	elif [ -x /usr/bin/tailscale ]; then
-		ts_bin=/usr/bin/tailscale
-	else
+	if [ ! -x /usr/sbin/tailscale ] && [ ! -x /usr/bin/tailscale ]; then
 		return 0
 	fi
 

--- a/luci-app-tailscale-community/root/etc/init.d/tailscale-settings
+++ b/luci-app-tailscale-community/root/etc/init.d/tailscale-settings
@@ -21,6 +21,64 @@ version_gte() {
 	return $?
 }
 
+# Add/remove DNS forward entry in dnsmasq for MagicDNS via OpenWrt
+setup_tailscale_dns_forward() {
+	local ts_bin
+	if [ -x /usr/sbin/tailscale ]; then
+		ts_bin=/usr/sbin/tailscale
+	elif [ -x /usr/bin/tailscale ]; then
+		ts_bin=/usr/bin/tailscale
+	else
+		return 0
+	fi
+
+	local entry="/.ts.net/100.100.100.100"
+	local found=0
+
+	# Check if entry already exists in dnsmasq
+	local idx=0
+	while true; do
+		local val
+		val=$(uci -q get dhcp.@dnsmasq[0].server."${idx}" 2>/dev/null)
+		[ -z "$val" ] && break
+		if [ "$val" = "$entry" ]; then
+			found=1
+			break
+		fi
+		idx=$((idx + 1))
+	done
+
+	if [ "$found" = "0" ]; then
+		uci add_list dhcp.@dnsmasq[0].server="$entry"
+		uci commit dhcp
+		/etc/init.d/dnsmasq reload 2>/dev/null || /etc/init.d/dnsmasq restart 2>/dev/null
+		logger -t "$NAME" "Added DNS forward: $entry"
+	fi
+}
+
+remove_tailscale_dns_forward() {
+	# Remove any dnsmasq server entries pointing to 100.100.100.100
+	local idx=0
+	local removed=0
+	while true; do
+		local val
+		val=$(uci -q get dhcp.@dnsmasq[0].server."${idx}" 2>/dev/null)
+		[ -z "$val" ] && break
+		if echo "$val" | grep -q '/100\.100\.100\.100$'; then
+			uci -q del dhcp.@dnsmasq[0].server."${idx}"
+			removed=1
+		else
+			idx=$((idx + 1))
+		fi
+	done
+
+	if [ "$removed" = "1" ]; then
+		uci commit dhcp
+		/etc/init.d/dnsmasq reload 2>/dev/null || /etc/init.d/dnsmasq restart 2>/dev/null
+		logger -t "$NAME" "Removed Tailscale DNS forward entry"
+	fi
+}
+
 apply_settings() {
 	local ts_bin
 	if [ -x /usr/sbin/tailscale ]; then
@@ -35,7 +93,7 @@ apply_settings() {
 	config_load tailscale
 
 	local accept_routes advertise_exit_node exit_node exit_node_allow_lan_access
-	local ssh disable_magic_dns shields_up runwebclient nosnat hostname
+	local ssh shields_up runwebclient nosnat hostname
 	local enable_relay relay_server_port
 
 	config_get accept_routes              settings accept_routes              '0'
@@ -43,7 +101,7 @@ apply_settings() {
 	config_get exit_node                  settings exit_node                  ''
 	config_get exit_node_allow_lan_access settings exit_node_allow_lan_access '0'
 	config_get ssh                        settings ssh                        '0'
-	config_get disable_magic_dns          settings disable_magic_dns          '0'
+	config_get dns_mode                   settings dns_mode                   'disabled'
 	config_get shields_up                 settings shields_up                 '0'
 	config_get runwebclient               settings runwebclient               '0'
 	config_get nosnat                     settings nosnat                     '0'
@@ -89,10 +147,22 @@ apply_settings() {
 		&& set -- "$@" --ssh=true \
 		|| set -- "$@" --ssh=false
 
-	# --accept-dns (inverse of disable_magic_dns)
-	[ "$disable_magic_dns" = "1" ] \
-		&& set -- "$@" --accept-dns=false \
-		|| set -- "$@" --accept-dns=true
+	# --accept-dns based on dns_mode
+	case "$dns_mode" in
+		magicdns)
+			set -- "$@" --accept-dns=true
+			remove_tailscale_dns_forward
+			;;
+		openwrt_forward)
+			set -- "$@" --accept-dns=false
+			setup_tailscale_dns_forward
+			;;
+		*)
+			# disabled (default)
+			set -- "$@" --accept-dns=false
+			remove_tailscale_dns_forward
+			;;
+	esac
 
 	# --shields-up
 	[ "$shields_up" = "1" ] \

--- a/luci-app-tailscale-community/root/etc/init.d/tailscale-settings
+++ b/luci-app-tailscale-community/root/etc/init.d/tailscale-settings
@@ -52,25 +52,25 @@ setup_tailscale_dns_forward() {
 }
 
 remove_tailscale_dns_forward() {
-	# Remove any dnsmasq server entries pointing to 100.100.100.100
+	local entry="/.ts.net/100.100.100.100"
 	local idx=0
 	local removed=0
 	while true; do
 		local val
 		val=$(uci -q get dhcp.@dnsmasq[0].server."${idx}" 2>/dev/null)
 		[ -z "$val" ] && break
-		if echo "$val" | grep -q '/100\.100\.100\.100$'; then
-			uci -q del dhcp.@dnsmasq[0].server."${idx}"
+		if [ "$val" = "$entry" ]; then
+			uci -q del_list dhcp.@dnsmasq[0].server="$entry"
 			removed=1
-		else
-			idx=$((idx + 1))
+			break
 		fi
+		idx=$((idx + 1))
 	done
 
 	if [ "$removed" = "1" ]; then
 		uci commit dhcp
 		/etc/init.d/dnsmasq reload 2>/dev/null || /etc/init.d/dnsmasq restart 2>/dev/null
-		logger -t "$NAME" "Removed Tailscale DNS forward entry"
+		logger -t "$NAME" "Removed Tailscale DNS forward entry: $entry"
 	fi
 }
 

--- a/luci-app-tailscale-community/root/usr/share/rpcd/ucode/tailscale.uc
+++ b/luci-app-tailscale-community/root/usr/share/rpcd/ucode/tailscale.uc
@@ -123,7 +123,7 @@ methods.get_settings = {
 					settings.ssh = status_data?.RunSSH || false;
 					settings.runwebclient = status_data?.RunWebClient || false;
 					settings.nosnat = status_data?.NoSNAT || false;
-					settings.disable_magic_dns = !status_data?.CorpDNS || false;
+					settings.dns_mode = uci.get('tailscale', 'settings', 'dns_mode') || 'disabled';
 					settings.fw_mode = split(uci.get('tailscale', 'settings', 'fw_mode'),' ')[0] || 'nftables';
 				}
 				}


### PR DESCRIPTION
https://github.com/openwrt/luci/issues/8641