### PR TITLE
feat: add SSR transparent proxy integration toggle

### DIFF
--- a/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js
+++ b/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js
@@ -27,7 +27,8 @@ const tailscaleSettingsConf = [
 	[form.Flag, 'ssh', _('Enable Tailscale SSH'), _('Allow connecting to this device through the SSH function of Tailscale.'), { rmempty: false }],
 	[form.ListValue, 'dns_mode', _('DNS Mode'), _('Controls how Tailscale DNS is handled.')+'<br>'+_('Disabled: system DNS only.')+'<br>'+_('MagicDNS: Tailscale overrides resolv.conf.')+'<br>'+_('OpenWrt Forward: MagicDNS via dnsmasq forwarding.(Only support ts.net)'), { values: [['disabled', _('Disabled')], ['magicdns', 'MagicDNS'], ['openwrt_forward', _('OpenWrt Forward')]], rmempty: false }],
 	[form.Flag, 'disable_fw_config', _('Disable Firewall Configuration'), _('Disable Tailscale netfilter auto-configuration (--netfilter-mode=off).'), { rmempty: false }],
-	[form.Flag, 'enable_relay', _('Enable Peer Relay'), _('Enable this device as a Peer Relay server. Requires a public IP and an UDP port open on the router.'), { rmempty: false }]
+	[form.Flag, 'enable_relay', _('Enable Peer Relay'), _('Enable this device as a Peer Relay server. Requires a public IP and an UDP port open on the router.'), { rmempty: false }],
+	[form.Flag, 'ssr_proxy_integration', _('SSR Proxy Integration'), _('Redirect Tailscale Exit Node traffic through SSR transparent proxy (SS_SPEC_WAN_AC). Requires SSR Plus+ installed.'), { rmempty: false }]
 ];
 
 const accountConf = [];	// dynamic created in render function

--- a/luci-app-tailscale-community/po/templates/community.pot
+++ b/luci-app-tailscale-community/po/templates/community.pot
@@ -553,3 +553,11 @@ msgid ""
 "and enables Masquerading and MSS Clamping (MTU fix) to ensure stable "
 "connections."
 msgstr ""
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:32
+msgid "SSR Proxy Integration"
+msgstr ""
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:32
+msgid "Redirect Tailscale Exit Node traffic through SSR transparent proxy (SS_SPEC_WAN_AC). Requires SSR Plus+ installed."
+msgstr ""

--- a/luci-app-tailscale-community/po/zh_Hans/community.po
+++ b/luci-app-tailscale-community/po/zh_Hans/community.po
@@ -561,6 +561,14 @@ msgid ""
 "connections."
 msgstr "并启用伪装和MSS钳制（MTU修复）功能，以确保连接稳定。"
 
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:32
+msgid "SSR Proxy Integration"
+msgstr "SSR 透明代理集成"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:32
+msgid "Redirect Tailscale Exit Node traffic through SSR transparent proxy (SS_SPEC_WAN_AC). Requires SSR Plus+ installed."
+msgstr "将 Tailscale 出口节点流量重定向至 SSR 透明代理 (SS_SPEC_WAN_AC)。需要已安装 SSR Plus+。"
+
 #~ msgid ""
 #~ "Completely disable all Tailscale firewall auto-configuration, including "
 #~ "zone creation, forwarding rules, and netfilter settings."

--- a/luci-app-tailscale-community/po/zh_Hant/community.po
+++ b/luci-app-tailscale-community/po/zh_Hant/community.po
@@ -561,6 +561,14 @@ msgid ""
 "connections."
 msgstr "並啟用地址偽裝和 MSS鉗制確保連線穩定。"
 
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:32
+msgid "SSR Proxy Integration"
+msgstr "SSR 透明代理整合"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:32
+msgid "Redirect Tailscale Exit Node traffic through SSR transparent proxy (SS_SPEC_WAN_AC). Requires SSR Plus+ installed."
+msgstr "將 Tailscale 出口節點流量重定向至 SSR 透明代理 (SS_SPEC_WAN_AC)。需要已安裝 SSR Plus+。"
+
 #~ msgid ""
 #~ "Completely disable all Tailscale firewall auto-configuration, including "
 #~ "zone creation, forwarding rules, and netfilter settings."

--- a/luci-app-tailscale-community/root/etc/init.d/tailscale-settings
+++ b/luci-app-tailscale-community/root/etc/init.d/tailscale-settings
@@ -66,6 +66,39 @@ remove_tailscale_dns_forward() {
 	fi
 }
 
+# Sync SSR transparent proxy rules in /etc/firewall.user
+sync_ssr_proxy_rules() {
+	config_load tailscale
+	local ssr_proxy_integration
+	config_get ssr_proxy_integration settings ssr_proxy_integration '0'
+
+	local FW_USER="/etc/firewall.user"
+	local MARK_BEGIN="# >>> SSR_PROXY_INTEGRATION_BEGIN (auto managed by tailscale-settings)"
+	local MARK_END="# <<< SSR_PROXY_INTEGRATION_END"
+
+	# Remove existing managed rules block
+	if [ -f "$FW_USER" ]; then
+		sed -i "/$MARK_BEGIN/,/$MARK_END/d" "$FW_USER"
+	fi
+
+	if [ "$ssr_proxy_integration" = "1" ]; then
+		{
+			echo "$MARK_BEGIN"
+			echo "# Redirect Tailscale Exit Node traffic through SSR transparent proxy"
+			echo "iptables -t nat -A PREROUTING -i tailscale0 -p tcp -j SS_SPEC_WAN_AC"
+			echo "$MARK_END"
+		} >> "$FW_USER"
+		logger -t "$NAME" "SSR proxy integration enabled: rules added to $FW_USER"
+	else
+		logger -t "$NAME" "SSR proxy integration disabled: rules removed from $FW_USER"
+	fi
+
+	# Reload firewall to apply changes
+	if /etc/init.d/firewall enabled 2>/dev/null; then
+		/etc/init.d/firewall reload 2>/dev/null || /etc/init.d/firewall restart 2>/dev/null
+	fi
+}
+
 apply_settings() {
 	local ts_bin
 	if [ -x /usr/sbin/tailscale ]; then
@@ -201,6 +234,10 @@ apply_settings() {
 	[ $ret -eq 0 ] \
 		&& logger -t "$NAME" "Settings applied successfully" \
 		|| logger -t "$NAME" "Failed to apply settings (exit code: $ret)"
+
+	# Sync SSR proxy firewall rules
+	sync_ssr_proxy_rules
+
 	return $ret
 }
 
@@ -224,6 +261,20 @@ handle_service_state() {
 
 start_service() {
 	apply_settings
+}
+
+stop_service() {
+	# Clean up SSR proxy rules on service stop
+	local FW_USER="/etc/firewall.user"
+	local MARK_BEGIN="# >>> SSR_PROXY_INTEGRATION_BEGIN (auto managed by tailscale-settings)"
+	local MARK_END="# <<< SSR_PROXY_INTEGRATION_END"
+	if [ -f "$FW_USER" ]; then
+		sed -i "/$MARK_BEGIN/,/$MARK_END/d" "$FW_USER"
+	fi
+	if /etc/init.d/firewall enabled 2>/dev/null; then
+		/etc/init.d/firewall reload 2>/dev/null || /etc/init.d/firewall restart 2>/dev/null
+	fi
+	logger -t "$NAME" "SSR proxy rules cleaned up on service stop"
 }
 
 service_triggers() {

--- a/luci-app-tailscale-community/root/etc/init.d/tailscale-settings
+++ b/luci-app-tailscale-community/root/etc/init.d/tailscale-settings
@@ -92,11 +92,6 @@ sync_ssr_proxy_rules() {
 		done
 		logger -t "$NAME" "SSR proxy integration disabled: rule removed"
 	fi
-
-	# Reload firewall to apply changes
-	if /etc/init.d/firewall enabled 2>/dev/null; then
-		/etc/init.d/firewall reload 2>/dev/null || /etc/init.d/firewall restart 2>/dev/null
-	fi
 }
 
 apply_settings() {

--- a/luci-app-tailscale-community/root/etc/init.d/tailscale-settings
+++ b/luci-app-tailscale-community/root/etc/init.d/tailscale-settings
@@ -72,25 +72,25 @@ sync_ssr_proxy_rules() {
 	local ssr_proxy_integration
 	config_get ssr_proxy_integration settings ssr_proxy_integration '0'
 
+	# Clean up leftover legacy firewall.user entries (migration from older version)
 	local FW_USER="/etc/firewall.user"
 	local MARK_BEGIN="# >>> SSR_PROXY_INTEGRATION_BEGIN (auto managed by tailscale-settings)"
 	local MARK_END="# <<< SSR_PROXY_INTEGRATION_END"
-
-	# Remove existing managed rules block
-	if [ -f "$FW_USER" ]; then
+	if [ -f "$FW_USER" ] && grep -q "$MARK_BEGIN" "$FW_USER" 2>/dev/null; then
 		sed -i "/$MARK_BEGIN/,/$MARK_END/d" "$FW_USER"
 	fi
 
+	# Direct iptables rule management — compatible with fw3 and fw4
 	if [ "$ssr_proxy_integration" = "1" ]; then
-		{
-			echo "$MARK_BEGIN"
-			echo "# Redirect Tailscale Exit Node traffic through SSR transparent proxy"
-			echo "iptables -t nat -A PREROUTING -i tailscale0 -p tcp -j SS_SPEC_WAN_AC"
-			echo "$MARK_END"
-		} >> "$FW_USER"
-		logger -t "$NAME" "SSR proxy integration enabled: rules added to $FW_USER"
+		if ! iptables -t nat -C PREROUTING -i tailscale0 -p tcp -j SS_SPEC_WAN_AC 2>/dev/null; then
+			iptables -t nat -A PREROUTING -i tailscale0 -p tcp -j SS_SPEC_WAN_AC
+			logger -t "$NAME" "SSR proxy integration enabled: rule added (tailscale0 -> SS_SPEC_WAN_AC)"
+		fi
 	else
-		logger -t "$NAME" "SSR proxy integration disabled: rules removed from $FW_USER"
+		while iptables -t nat -C PREROUTING -i tailscale0 -p tcp -j SS_SPEC_WAN_AC 2>/dev/null; do
+			iptables -t nat -D PREROUTING -i tailscale0 -p tcp -j SS_SPEC_WAN_AC
+		done
+		logger -t "$NAME" "SSR proxy integration disabled: rule removed"
 	fi
 
 	# Reload firewall to apply changes
@@ -264,17 +264,11 @@ start_service() {
 }
 
 stop_service() {
-	# Clean up SSR proxy rules on service stop
-	local FW_USER="/etc/firewall.user"
-	local MARK_BEGIN="# >>> SSR_PROXY_INTEGRATION_BEGIN (auto managed by tailscale-settings)"
-	local MARK_END="# <<< SSR_PROXY_INTEGRATION_END"
-	if [ -f "$FW_USER" ]; then
-		sed -i "/$MARK_BEGIN/,/$MARK_END/d" "$FW_USER"
-	fi
-	if /etc/init.d/firewall enabled 2>/dev/null; then
-		/etc/init.d/firewall reload 2>/dev/null || /etc/init.d/firewall restart 2>/dev/null
-	fi
-	logger -t "$NAME" "SSR proxy rules cleaned up on service stop"
+	# Clean up SSR proxy iptables rule on service stop
+	while iptables -t nat -C PREROUTING -i tailscale0 -p tcp -j SS_SPEC_WAN_AC 2>/dev/null; do
+		iptables -t nat -D PREROUTING -i tailscale0 -p tcp -j SS_SPEC_WAN_AC
+	done
+	logger -t "$NAME" "SSR proxy rule cleaned up on service stop"
 }
 
 service_triggers() {


### PR DESCRIPTION
- Add 'SSR Proxy Integration' Flag option in tailscale.js settings config
- Add sync_ssr_proxy_rules() in tailscale-settings init script to dynamically add/remove iptables rules in /etc/firewall.user based on UCI setting
- Add stop_service() to clean up SSR proxy rules on service stop
- Add i18n translations for zh_Hans, zh_Hant and update POT template