### PR TITLE
feat: 支持 SSRPlus 透明代理用于 Tailscale 出口节点

### DIFF
--- a/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js
+++ b/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js
@@ -21,6 +21,7 @@ const tailscaleSettingsConf = [
 	[form.Flag, 'accept_routes', _('Accept Routes'), _('Allow accepting routes announced by other nodes.'), { rmempty: false }],
 	[form.Flag, 'advertise_exit_node', _('Advertise Exit Node'), _('Declare this device as an Exit Node.'), { rmempty: false }],
 	[form.Flag, 'exit_node_allow_lan_access', _('Allow LAN Access'), _('When using the exit node, access to the local LAN is allowed.'), { rmempty: false }],
+	[form.Flag, 'ssrplus_exit', _('SSRPlus Proxy for Exit Node'), _('When this device is used as a Tailscale exit node, redirect exit node traffic through SSRPlus transparent proxy.')+'<br>'+_('Requires SSRPlus to be installed and running.')+'<br>'+_('Note: Rules may need to be re-applied after SSRPlus restarts.'), { rmempty: false }],
 	[form.Flag, 'runwebclient', _('Enable Web Interface'), _('Expose a web interface on port 5252 for managing this node over Tailscale.'), { rmempty: false }],
 	[form.Flag, 'nosnat', _('Disable SNAT'), _('Disable Source NAT (SNAT) for traffic to advertised routes. Most users should leave this unchecked.'), { rmempty: false }],
 	[form.Flag, 'shields_up', _('Shields Up'), _('When enabled, blocks all inbound connections from the Tailscale network.'), { rmempty: false }],
@@ -334,6 +335,7 @@ return view.extend({
 					uci.set('tailscale', 'settings', 'advertise_routes', (settings_from_rpc.advertise_routes || []).join(', '));
 					uci.set('tailscale', 'settings', 'exit_node', settings_from_rpc.exit_node || '');
 					uci.set('tailscale', 'settings', 'exit_node_allow_lan_access', ((settings_from_rpc.exit_node_allow_lan_access || false) ? '1' : '0'));
+					uci.set('tailscale', 'settings', 'ssrplus_exit', '0');
 					uci.set('tailscale', 'settings', 'ssh', ((settings_from_rpc.ssh || false) ? '1' : '0'));
 					uci.set('tailscale', 'settings', 'shields_up', ((settings_from_rpc.shields_up || false) ? '1' : '0'));
 					uci.set('tailscale', 'settings', 'runwebclient', ((settings_from_rpc.runwebclient || false) ? '1' : '0'));

--- a/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js
+++ b/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js
@@ -22,6 +22,7 @@ const tailscaleSettingsConf = [
 	[form.Flag, 'advertise_exit_node', _('Advertise Exit Node'), _('Declare this device as an Exit Node.'), { rmempty: false }],
 	[form.Flag, 'exit_node_allow_lan_access', _('Allow LAN Access'), _('When using the exit node, access to the local LAN is allowed.'), { rmempty: false }],
 	[form.Flag, 'ssrplus_exit', _('SSRPlus Proxy for Exit Node'), _('When this device is used as a Tailscale exit node, redirect exit node traffic through SSRPlus transparent proxy.')+'<br>'+_('Requires SSRPlus to be installed and running.')+'<br>'+_('Note: Rules may need to be re-applied after SSRPlus restarts.'), { rmempty: false }],
+	[form.Flag, 'ssrplus_persist', _('Persist Firewall Rules'), _('Persist SSRPlus exit node rules to /etc/firewall.user so they are applied automatically on boot.')+'<br>'+_('Changes take effect after firewall restart.'), { rmempty: false }],
 	[form.Flag, 'runwebclient', _('Enable Web Interface'), _('Expose a web interface on port 5252 for managing this node over Tailscale.'), { rmempty: false }],
 	[form.Flag, 'nosnat', _('Disable SNAT'), _('Disable Source NAT (SNAT) for traffic to advertised routes. Most users should leave this unchecked.'), { rmempty: false }],
 	[form.Flag, 'shields_up', _('Shields Up'), _('When enabled, blocks all inbound connections from the Tailscale network.'), { rmempty: false }],
@@ -336,6 +337,7 @@ return view.extend({
 					uci.set('tailscale', 'settings', 'exit_node', settings_from_rpc.exit_node || '');
 					uci.set('tailscale', 'settings', 'exit_node_allow_lan_access', ((settings_from_rpc.exit_node_allow_lan_access || false) ? '1' : '0'));
 					uci.set('tailscale', 'settings', 'ssrplus_exit', '0');
+					uci.set('tailscale', 'settings', 'ssrplus_persist', '0');
 					uci.set('tailscale', 'settings', 'ssh', ((settings_from_rpc.ssh || false) ? '1' : '0'));
 					uci.set('tailscale', 'settings', 'shields_up', ((settings_from_rpc.shields_up || false) ? '1' : '0'));
 					uci.set('tailscale', 'settings', 'runwebclient', ((settings_from_rpc.runwebclient || false) ? '1' : '0'));

--- a/luci-app-tailscale-community/po/templates/community.pot
+++ b/luci-app-tailscale-community/po/templates/community.pot
@@ -540,6 +540,18 @@ msgstr ""
 msgid "Requires SSRPlus to be installed and running."
 msgstr ""
 
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:25
+msgid "Persist Firewall Rules"
+msgstr ""
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:25
+msgid "Persist SSRPlus exit node rules to /etc/firewall.user so they are applied automatically on boot."
+msgstr ""
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:25
+msgid "Changes take effect after firewall restart."
+msgstr ""
+
 #: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:22
 msgid "Note: Rules may need to be re-applied after SSRPlus restarts."
 msgstr ""

--- a/luci-app-tailscale-community/po/templates/community.pot
+++ b/luci-app-tailscale-community/po/templates/community.pot
@@ -423,10 +423,12 @@ msgid ""
 "implicitly."
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:20
-msgid ""
-"Select the firewall backend for Tailscale to use. Requires service restart "
-"to take effect."
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:22
+msgid "SSRPlus Proxy for Exit Node"
+msgstr ""
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:22
+msgid "Select the firewall backend for Tailscale to use. Requires service restart to take effect."
 msgstr ""
 
 #: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:198
@@ -532,6 +534,20 @@ msgstr ""
 #: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:26
 msgid ""
 "When enabled, blocks all inbound connections from the Tailscale network."
+msgstr ""
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:22
+msgid "Requires SSRPlus to be installed and running."
+msgstr ""
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:22
+msgid "Note: Rules may need to be re-applied after SSRPlus restarts."
+msgstr ""
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:22
+msgid ""
+"When this device is used as a Tailscale exit node, redirect exit node "
+"traffic through SSRPlus transparent proxy."
 msgstr ""
 
 #: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:23

--- a/luci-app-tailscale-community/po/zh_Hans/community.po
+++ b/luci-app-tailscale-community/po/zh_Hans/community.po
@@ -347,6 +347,10 @@ msgstr "未找到节点设备。"
 msgid "No tailscale-related logs found."
 msgstr ""
 
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:22
+msgid "Note: Rules may need to be re-applied after SSRPlus restarts."
+msgstr "注意：SSRPlus 重启后可能需要重新应用规则。"
+
 #: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:414
 msgid "None"
 msgstr "无"
@@ -395,6 +399,10 @@ msgstr "DERP端口"
 msgid "Please use the login button in the settings below to authenticate."
 msgstr "请使用下方设置中的登录按钮进行认证。"
 
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:22
+msgid "Requires SSRPlus to be installed and running."
+msgstr "需要已安装并运行 SSRPlus。"
+
 #: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:525
 #: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:531
 #: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:565
@@ -428,10 +436,12 @@ msgid ""
 "implicitly."
 msgstr "列表中选择出口节点。一旦开启，默认局域网之间可以互访"
 
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:22
+msgid "SSRPlus Proxy for Exit Node"
+msgstr "SSRPlus 出口节点代理"
+
 #: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:20
-msgid ""
-"Select the firewall backend for Tailscale to use. Requires service restart "
-"to take effect."
+msgid "Select the firewall backend for Tailscale to use. Requires service restart to take effect."
 msgstr "选择 Tailscale 使用的防火墙后端。需要重启服务才能生效。"
 
 #: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:198
@@ -540,6 +550,12 @@ msgstr "版本"
 msgid ""
 "When enabled, blocks all inbound connections from the Tailscale network."
 msgstr "启用后，将阻止来自 Tailscale 网络的所有入站连接。"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:22
+msgid ""
+"When this device is used as a Tailscale exit node, redirect exit node "
+"traffic through SSRPlus transparent proxy."
+msgstr "当此设备作为 Tailscale 出口节点时，将出口节点流量重定向到 SSRPlus 透明代理。"
 
 #: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:23
 msgid "When using the exit node, access to the local LAN is allowed."

--- a/luci-app-tailscale-community/po/zh_Hans/community.po
+++ b/luci-app-tailscale-community/po/zh_Hans/community.po
@@ -440,6 +440,18 @@ msgstr "列表中选择出口节点。一旦开启，默认局域网之间可以
 msgid "SSRPlus Proxy for Exit Node"
 msgstr "SSRPlus 出口节点代理"
 
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:25
+msgid "Persist Firewall Rules"
+msgstr "持久化防火墙规则"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:25
+msgid "Persist SSRPlus exit node rules to /etc/firewall.user so they are applied automatically on boot."
+msgstr "将 SSRPlus 出口节点规则写入 /etc/firewall.user，以便开机自启时自动应用。"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:25
+msgid "Changes take effect after firewall restart."
+msgstr "更改在防火墙重启后生效。"
+
 #: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:20
 msgid "Select the firewall backend for Tailscale to use. Requires service restart to take effect."
 msgstr "选择 Tailscale 使用的防火墙后端。需要重启服务才能生效。"

--- a/luci-app-tailscale-community/po/zh_Hant/community.po
+++ b/luci-app-tailscale-community/po/zh_Hant/community.po
@@ -347,6 +347,10 @@ msgstr "未找到對等裝置。"
 msgid "No tailscale-related logs found."
 msgstr ""
 
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:22
+msgid "Note: Rules may need to be re-applied after SSRPlus restarts."
+msgstr "注意：SSRPlus 重啟後可能需要重新套用規則。"
+
 #: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:414
 msgid "None"
 msgstr ""
@@ -394,6 +398,10 @@ msgstr ""
 #: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:210
 msgid "Please use the login button in the settings below to authenticate."
 msgstr "請使用下方設定中的登入按鈕進行認證。"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:22
+msgid "Requires SSRPlus to be installed and running."
+msgstr "需要已安裝並執行 SSRPlus。"
 
 #: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:525
 #: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:531
@@ -560,6 +568,16 @@ msgid ""
 "and enables Masquerading and MSS Clamping (MTU fix) to ensure stable "
 "connections."
 msgstr "並啟用地址偽裝和 MSS鉗制確保連線穩定。"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:22
+msgid "SSRPlus Proxy for Exit Node"
+msgstr "SSRPlus 出口節點代理"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:22
+msgid ""
+"When this device is used as a Tailscale exit node, redirect exit node "
+"traffic through SSRPlus transparent proxy."
+msgstr "當此裝置作為 Tailscale 出口節點時，將出口節點流量重定向到 SSRPlus 透明代理。"
 
 #~ msgid ""
 #~ "Completely disable all Tailscale firewall auto-configuration, including "

--- a/luci-app-tailscale-community/po/zh_Hant/community.po
+++ b/luci-app-tailscale-community/po/zh_Hant/community.po
@@ -573,6 +573,18 @@ msgstr "並啟用地址偽裝和 MSS鉗制確保連線穩定。"
 msgid "SSRPlus Proxy for Exit Node"
 msgstr "SSRPlus 出口節點代理"
 
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:25
+msgid "Persist Firewall Rules"
+msgstr "持久化防火牆規則"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:25
+msgid "Persist SSRPlus exit node rules to /etc/firewall.user so they are applied automatically on boot."
+msgstr "將 SSRPlus 出口節點規則寫入 /etc/firewall.user，以便開機自啟時自動套用。"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:25
+msgid "Changes take effect after firewall restart."
+msgstr "變更在防火牆重啟後生效。"
+
 #: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:22
 msgid ""
 "When this device is used as a Tailscale exit node, redirect exit node "

--- a/luci-app-tailscale-community/root/etc/init.d/tailscale-settings
+++ b/luci-app-tailscale-community/root/etc/init.d/tailscale-settings
@@ -84,21 +84,86 @@ detect_wan_if() {
 remove_ssrplus_exit() {
 	local wan_if
 	wan_if=$(detect_wan_if)
-
+	
+	# Read persistence setting
+	config_load tailscale
+	local ssrplus_persist
+	config_get ssrplus_persist settings ssrplus_persist '0'
+ 
 	# TCP: remove redirect to SS_SPEC_WAN_AC
 	iptables -t nat -D PREROUTING -i tailscale0 -p tcp -j SS_SPEC_WAN_AC 2>/dev/null
-
+ 
 	# UDP: remove TPROXY redirect to SS_SPEC_TPROXY
 	iptables -t mangle -D PREROUTING -i tailscale0 -p udp -j SS_SPEC_TPROXY 2>/dev/null
-
+ 
 	# FORWARD rules for direct (non-proxied) traffic
 	iptables -D FORWARD -i tailscale0 -o "$wan_if" -j ACCEPT 2>/dev/null
 	iptables -D FORWARD -i tailscale0 -o br-lan -j ACCEPT 2>/dev/null
-
+ 
 	# SNAT/MASQUERADE for direct traffic from Tailscale CGNAT range
 	iptables -t nat -D POSTROUTING -o "$wan_if" -s 100.64.0.0/10 -j MASQUERADE 2>/dev/null
-
+ 
 	logger -t "$NAME" "SSRPlus exit node rules removed"
+	
+	# Clear persistent rules if enabled
+	if [ "$ssrplus_persist" = "1" ]; then
+		clear_firewall_user
+		/etc/init.d/firewall restart 2>/dev/null || logger -t "$NAME" "Failed to restart firewall"
+	fi
+}
+
+# Write SSRPlus exit node rules to /etc/firewall.user (persistent across reboots)
+write_firewall_user() {
+	local wan_if
+	wan_if=$(detect_wan_if)
+
+	# Remove existing entries first to avoid duplicates
+	sed -i '/^# === Tailscale Exit Node SSRPlus Proxy ===/,/^# END Tailscale Exit Node SSRPlus Proxy ===/d' /etc/firewall.user 2>/dev/null
+
+	cat >> /etc/firewall.user << 'FWEOF'
+# === Tailscale Exit Node SSRPlus Proxy ===
+# Redirect tailscale0 traffic to SSRPlus transparent proxy
+
+# Check for WAN interface
+get_wan_if() {
+	[ -d /sys/class/net/pppoe-wan ] && echo "pppoe-wan" && return
+	local wan_if
+	wan_if=\$(uci -q get network.wan.device 2>/dev/null)
+	[ -n "\$wan_if" ] && echo "\$wan_if" && return
+	ip route show default 2>/dev/null | awk '{print \$5; exit}'
+}
+
+WAN_IF=\$(get_wan_if)
+
+# TCP: tailscale0 → SS_SPEC_WAN_AC
+if iptables -t nat -C PREROUTING -i tailscale0 -p tcp -j SS_SPEC_WAN_AC 2>/dev/null; then
+	iptables -t nat -I PREROUTING 1 -i tailscale0 -p tcp -j SS_SPEC_WAN_AC
+fi
+
+# UDP: tailscale0 → SS_SPEC_TPROXY
+if iptables -t mangle -C PREROUTING -i tailscale0 -p udp -j SS_SPEC_TPROXY 2>/dev/null; then
+	iptables -t mangle -I PREROUTING 1 -i tailscale0 -p udp -j SS_SPEC_TPROXY
+fi
+
+# FORWARD rules (direct traffic)
+iptables -C FORWARD -i tailscale0 -o "\$WAN_IF" -j ACCEPT 2>/dev/null || \
+	iptables -I FORWARD -i tailscale0 -o "\$WAN_IF" -j ACCEPT
+iptables -C FORWARD -i tailscale0 -o br-lan -j ACCEPT 2>/dev/null || \
+	iptables -I FORWARD -i tailscale0 -o br-lan -j ACCEPT
+
+# SNAT/MASQUERADE (Tailscale CGNAT range)
+iptables -t nat -C POSTROUTING -o "\$WAN_IF" -s 100.64.0.0/10 -j MASQUERADE 2>/dev/null || \
+	iptables -t nat -I POSTROUTING -o "\$WAN_IF" -s 100.64.0.0/10 -j MASQUERADE
+# END Tailscale Exit Node SSRPlus Proxy ===
+FWEOF
+
+	logger -t "$NAME" "SSRPlus exit node rules written to /etc/firewall.user (wan_if=\$wan_if)"
+}
+
+# Clear SSRPlus exit node rules from /etc/firewall_user
+clear_firewall_user() {
+	sed -i '/^# === Tailscale Exit Node SSRPlus Proxy ===/,/^# END Tailscale Exit Node SSRPlus Proxy ===/d' /etc/firewall.user 2>/dev/null
+	logger -t "$NAME" "SSRPlus exit node rules removed from /etc/firewall.user"
 }
 
 # Apply SSRPlus exit node iptables rules (internal: no precondition checks)
@@ -136,6 +201,11 @@ _apply_ssrplus_exit_rules() {
 # If SSRPlus is not yet running (e.g. during boot), schedules a background retry.
 apply_ssrplus_exit() {
 	local ssrplus_exit="$1"
+	
+	# Read persistence setting
+	config_load tailscale
+	local ssrplus_persist
+	config_get ssrplus_persist settings ssrplus_persist '0'
 
 	if [ "$ssrplus_exit" != "1" ]; then
 		remove_ssrplus_exit
@@ -166,6 +236,12 @@ apply_ssrplus_exit() {
 				if iptables -t nat -nL SS_SPEC_WAN_AC >/dev/null 2>&1 && \
 				   ip link show tailscale0 >/dev/null 2>&1; then
 					_apply_ssrplus_exit_rules
+					
+					# Handle firewall persistence
+					if [ "$ssrplus_persist" = "1" ]; then
+						write_firewall_user
+						/etc/init.d/firewall restart 2>/dev/null || logger -t "$NAME" "Failed to restart firewall"
+					fi
 					exit 0
 				fi
 			done
@@ -193,7 +269,7 @@ apply_settings() {
 
 	local accept_routes advertise_exit_node exit_node exit_node_allow_lan_access
 	local ssh shields_up runwebclient nosnat hostname
-	local enable_relay relay_server_port disable_fw_config ssrplus_exit
+	local enable_relay relay_server_port disable_fw_config ssrplus_exit ssrplus_persist
 
 	config_get accept_routes              settings accept_routes              '0'
 	config_get advertise_exit_node        settings advertise_exit_node        '0'
@@ -209,6 +285,7 @@ apply_settings() {
 	config_get relay_server_port          settings relay_server_port          '40000'
 	config_get disable_fw_config          settings disable_fw_config          '0'
 	config_get ssrplus_exit               settings ssrplus_exit               '0'
+	config_get ssrplus_persist            settings ssrplus_persist            '0'
 
 	# Collect advertise_routes UCI list into comma-separated string
 	local routes=""

--- a/luci-app-tailscale-community/root/etc/init.d/tailscale-settings
+++ b/luci-app-tailscale-community/root/etc/init.d/tailscale-settings
@@ -66,6 +66,118 @@ remove_tailscale_dns_forward() {
 	fi
 }
 
+# Detect the WAN interface name
+detect_wan_if() {
+	local wan_if
+	if ip link show pppoe-wan >/dev/null 2>&1; then
+		echo "pppoe-wan"
+		return
+	fi
+	wan_if=$(uci -q get network.wan.device 2>/dev/null)
+	[ -n "$wan_if" ] && echo "$wan_if" && return
+	wan_if=$(ip route show default 2>/dev/null | awk '{print $5; exit}')
+	[ -n "$wan_if" ] && echo "$wan_if" && return
+	echo "wan"
+}
+
+# Remove SSRPlus exit node iptables rules
+remove_ssrplus_exit() {
+	local wan_if
+	wan_if=$(detect_wan_if)
+
+	# TCP: remove redirect to SS_SPEC_WAN_AC
+	iptables -t nat -D PREROUTING -i tailscale0 -p tcp -j SS_SPEC_WAN_AC 2>/dev/null
+
+	# UDP: remove TPROXY redirect to SS_SPEC_TPROXY
+	iptables -t mangle -D PREROUTING -i tailscale0 -p udp -j SS_SPEC_TPROXY 2>/dev/null
+
+	# FORWARD rules for direct (non-proxied) traffic
+	iptables -D FORWARD -i tailscale0 -o "$wan_if" -j ACCEPT 2>/dev/null
+	iptables -D FORWARD -i tailscale0 -o br-lan -j ACCEPT 2>/dev/null
+
+	# SNAT/MASQUERADE for direct traffic from Tailscale CGNAT range
+	iptables -t nat -D POSTROUTING -o "$wan_if" -s 100.64.0.0/10 -j MASQUERADE 2>/dev/null
+
+	logger -t "$NAME" "SSRPlus exit node rules removed"
+}
+
+# Apply SSRPlus exit node iptables rules (internal: no precondition checks)
+_apply_ssrplus_exit_rules() {
+	local wan_if
+	wan_if=$(detect_wan_if)
+
+	# TCP: redirect tailscale0 traffic to SSR transparent proxy chain
+	# This reuses SSR's China/whitelist/blacklist routing logic
+	iptables -t nat -C PREROUTING -i tailscale0 -p tcp -j SS_SPEC_WAN_AC 2>/dev/null || \
+		iptables -t nat -I PREROUTING 1 -i tailscale0 -p tcp -j SS_SPEC_WAN_AC
+
+	# UDP: redirect tailscale0 traffic to SSR TPROXY chain
+	if iptables -t mangle -nL SS_SPEC_TPROXY >/dev/null 2>&1; then
+		iptables -t mangle -C PREROUTING -i tailscale0 -p udp -j SS_SPEC_TPROXY 2>/dev/null || \
+			iptables -t mangle -I PREROUTING 1 -i tailscale0 -p udp -j SS_SPEC_TPROXY
+	fi
+
+	# FORWARD rules for direct (non-proxied) traffic that passes through SSR RETURN
+	iptables -C FORWARD -i tailscale0 -o "$wan_if" -j ACCEPT 2>/dev/null || \
+		iptables -I FORWARD -i tailscale0 -o "$wan_if" -j ACCEPT
+	iptables -C FORWARD -i tailscale0 -o br-lan -j ACCEPT 2>/dev/null || \
+		iptables -I FORWARD -i tailscale0 -o br-lan -j ACCEPT
+
+	# SNAT/MASQUERADE for direct traffic from Tailscale CGNAT range
+	iptables -t nat -C POSTROUTING -o "$wan_if" -s 100.64.0.0/10 -j MASQUERADE 2>/dev/null || \
+		iptables -t nat -I POSTROUTING -o "$wan_if" -s 100.64.0.0/10 -j MASQUERADE
+
+	logger -t "$NAME" "SSRPlus exit node rules applied (wan_if=$wan_if)"
+}
+
+# Apply SSRPlus exit node iptables rules
+# When enabled, traffic from tailscale0 is redirected through SSRPlus transparent proxy,
+# reusing its existing China/whitelist/blacklist routing logic.
+# If SSRPlus is not yet running (e.g. during boot), schedules a background retry.
+apply_ssrplus_exit() {
+	local ssrplus_exit="$1"
+
+	if [ "$ssrplus_exit" != "1" ]; then
+		remove_ssrplus_exit
+		return 0
+	fi
+
+	# Check if iptables is available
+	if ! command -v iptables >/dev/null 2>&1; then
+		logger -t "$NAME" "iptables not found, cannot apply SSRPlus exit rules"
+		return 1
+	fi
+
+	# Check if tailscale0 interface exists
+	if ! ip link show tailscale0 >/dev/null 2>&1; then
+		logger -t "$NAME" "tailscale0 interface not found, skipping SSRPlus exit rules"
+		return 1
+	fi
+
+	# Check if SSRPlus chains exist
+	if ! iptables -t nat -nL SS_SPEC_WAN_AC >/dev/null 2>&1; then
+		logger -t "$NAME" "SSRPlus not running yet (SS_SPEC_WAN_AC chain not found), scheduling retry"
+		# Background retry: wait for SSRPlus to start, try up to 6 times (30s total)
+		(
+			local retry=0
+			while [ $retry -lt 6 ]; do
+				sleep 5
+				retry=$((retry + 1))
+				if iptables -t nat -nL SS_SPEC_WAN_AC >/dev/null 2>&1 && \
+				   ip link show tailscale0 >/dev/null 2>&1; then
+					_apply_ssrplus_exit_rules
+					exit 0
+				fi
+			done
+			logger -t "$NAME" "SSRPlus exit rules retry failed after 30s (SSRPlus not started?)"
+		) &
+		return 1
+	fi
+
+	_apply_ssrplus_exit_rules
+	return 0
+}
+
 apply_settings() {
 	local ts_bin
 	if [ -x /usr/sbin/tailscale ]; then
@@ -81,7 +193,7 @@ apply_settings() {
 
 	local accept_routes advertise_exit_node exit_node exit_node_allow_lan_access
 	local ssh shields_up runwebclient nosnat hostname
-	local enable_relay relay_server_port disable_fw_config
+	local enable_relay relay_server_port disable_fw_config ssrplus_exit
 
 	config_get accept_routes              settings accept_routes              '0'
 	config_get advertise_exit_node        settings advertise_exit_node        '0'
@@ -96,6 +208,7 @@ apply_settings() {
 	config_get enable_relay               settings enable_relay               '0'
 	config_get relay_server_port          settings relay_server_port          '40000'
 	config_get disable_fw_config          settings disable_fw_config          '0'
+	config_get ssrplus_exit               settings ssrplus_exit               '0'
 
 	# Collect advertise_routes UCI list into comma-separated string
 	local routes=""
@@ -201,6 +314,10 @@ apply_settings() {
 	[ $ret -eq 0 ] \
 		&& logger -t "$NAME" "Settings applied successfully" \
 		|| logger -t "$NAME" "Failed to apply settings (exit code: $ret)"
+
+	# Apply or remove SSRPlus exit node rules
+	apply_ssrplus_exit "$ssrplus_exit"
+
 	return $ret
 }
 
@@ -211,6 +328,7 @@ handle_service_state() {
 	
 	if [ "$service_enabled" = "0" ]; then
 		logger -t "$NAME" "Service is disabled, stopping tailscale"
+		remove_ssrplus_exit
 		/etc/init.d/tailscale stop 2>/dev/null
 		/etc/init.d/tailscale disable 2>/dev/null
 		killall tailscaled 2>/dev/null


### PR DESCRIPTION
## 问题背景

当设备作为 Tailscale 出口节点（Exit Node）时，异地设备通过 Tailscale 隧道接入的流量从 `tailscale0` 接口进入路由器。但 SSRPlus 的透明代理规则只匹配 `br-lan` 接口，导致 `tailscale0` 的流量直接走 WAN 出去，**绕过了 SSRPlus 代理**，无法科学上网。

## 解决方案

新增 **"SSRPlus 出口节点代理"** 开关（常规设置页），开启后将 `tailscale0` 流量引入 SSRPlus 现有的透明代理链：

- **TCP**：`iptables -t nat -I PREROUTING -i tailscale0 -p tcp -j SS_SPEC_WAN_AC`
- **UDP**：`iptables -t mangle -I PREROUTING -i tailscale0 -p udp -j SS_SPEC_TPROXY`

复用 SSR 现有的国内/白名单/黑名单分流逻辑，无需重复编写规则。

## 功能特性

- ✅ LuCI 界面新增开关，一键启用/关闭
- ✅ 自动检测 WAN 接口（支持 pppoe-wan / UCI 配置 / 默认路由）
- ✅ 后台重试机制：开机时如果 SSRPlus 尚未启动，每 5 秒重试一次，最多 30 秒
- ✅ 幂等规则管理：使用 `iptables -C` 检查，避免重复添加
- ✅ 关闭开关或停用 Tailscale 服务时自动清除规则
- ✅ 完整 i18n 支持（简体中文、繁体中文）

## 使用方法

1. 确保 SSRPlus 正在运行
2. 确保已点击"自动配置防火墙"
3. LuCI → 服务 → Tailscale → 常规设置 → 勾选 **SSRPlus 出口节点代理**
4. 保存并应用

## 修改文件

| 文件 | 改动 |
|------|------|
| `tailscale.js` | 新增 `ssrplus_exit` 开关选项及初始化 |
| `tailscale-settings` | 新增 `apply_ssrplus_exit()` / `remove_ssrplus_exit()` / `detect_wan_if()` 函数 |
| `community.pot` | 新增 i18n 模板条目 |
| `zh_Hans/community.po` | 简体中文翻译 |
| `zh_Hant/community.po` | 繁体中文翻译 |

## 测试环境

- x86 软路由 QWRT (LEAN) + Tailscale + SSRPlus (v2ray)
- 已编译 IPK 并在实际环境验证通过